### PR TITLE
FE gets current data from 기상청 API

### DIFF
--- a/weather/src/main/generated/com/practice/weather/midTerm/land/entity/QMidTermLandEntity.java
+++ b/weather/src/main/generated/com/practice/weather/midTerm/land/entity/QMidTermLandEntity.java
@@ -2,7 +2,6 @@ package com.practice.weather.midTerm.land.entity;
 
 import static com.querydsl.core.types.PathMetadataFactory.*;
 
-import com.practice.weather.baseEntity.QBaseEntity;
 import com.querydsl.core.types.dsl.*;
 
 import com.querydsl.core.types.PathMetadata;
@@ -20,7 +19,7 @@ public class QMidTermLandEntity extends EntityPathBase<MidTermLandEntity> {
 
     public static final QMidTermLandEntity midTermLandEntity = new QMidTermLandEntity("midTermLandEntity");
 
-    public final QBaseEntity _super = new QBaseEntity(this);
+    public final com.practice.weather.baseEntity.QBaseEntity _super = new com.practice.weather.baseEntity.QBaseEntity(this);
 
     //inherited
     public final DateTimePath<java.time.LocalDateTime> date = _super.date;

--- a/weather/src/main/java/com/practice/weather/midTerm/land/entity/MidTermLandEntity.java
+++ b/weather/src/main/java/com/practice/weather/midTerm/land/entity/MidTermLandEntity.java
@@ -13,6 +13,11 @@ import javax.persistence.*;
 @NoArgsConstructor
 @Table(name = "mid_term_land")
 @Entity(name = "MidTermLandEntity")
+@SequenceGenerator(
+        name = "MID_TERM_LAND_ID_GENERATOR",
+        sequenceName = "MID_TERM_LAND_ID",
+        initialValue = 1,
+        allocationSize = 1)
 public class MidTermLandEntity extends BaseEntity {
 
     @Id


### PR DESCRIPTION
### regarding issue
- #16 

### key changes
- midTermEntity had sequence generator deleted by mistake at the last commit and it has been re-added
- mid/short-term current methods, alter map to dto methods, getVersion, get baseDate/Time methods are all no-longer used and will be deprecated at the next commit

### note
-
