### PR TITLE
Feature#16

### DIFF
--- a/weather/src/main/generated/com/practice/weather/baseEntity/QBaseEntity.java
+++ b/weather/src/main/generated/com/practice/weather/baseEntity/QBaseEntity.java
@@ -15,7 +15,7 @@ import com.querydsl.core.types.Path;
 @Generated("com.querydsl.codegen.DefaultSupertypeSerializer")
 public class QBaseEntity extends EntityPathBase<BaseEntity> {
 
-    private static final long serialVersionUID = -1337212150L;
+    private static final long serialVersionUID = -640375954L;
 
     public static final QBaseEntity baseEntity = new QBaseEntity("baseEntity");
 

--- a/weather/src/main/generated/com/practice/weather/midTerm/expectation/entity/QMidTermExpectationEntity.java
+++ b/weather/src/main/generated/com/practice/weather/midTerm/expectation/entity/QMidTermExpectationEntity.java
@@ -2,7 +2,6 @@ package com.practice.weather.midTerm.expectation.entity;
 
 import static com.querydsl.core.types.PathMetadataFactory.*;
 
-import com.practice.weather.baseEntity.QBaseEntity;
 import com.querydsl.core.types.dsl.*;
 
 import com.querydsl.core.types.PathMetadata;
@@ -20,7 +19,7 @@ public class QMidTermExpectationEntity extends EntityPathBase<MidTermExpectation
 
     public static final QMidTermExpectationEntity midTermExpectationEntity = new QMidTermExpectationEntity("midTermExpectationEntity");
 
-    public final QBaseEntity _super = new QBaseEntity(this);
+    public final com.practice.weather.baseEntity.QBaseEntity _super = new com.practice.weather.baseEntity.QBaseEntity(this);
 
     //inherited
     public final DateTimePath<java.time.LocalDateTime> date = _super.date;

--- a/weather/src/main/generated/com/practice/weather/midTerm/land/entity/QMidTermLandEntity.java
+++ b/weather/src/main/generated/com/practice/weather/midTerm/land/entity/QMidTermLandEntity.java
@@ -2,7 +2,6 @@ package com.practice.weather.midTerm.land.entity;
 
 import static com.querydsl.core.types.PathMetadataFactory.*;
 
-import com.practice.weather.baseEntity.QBaseEntity;
 import com.querydsl.core.types.dsl.*;
 
 import com.querydsl.core.types.PathMetadata;
@@ -20,7 +19,7 @@ public class QMidTermLandEntity extends EntityPathBase<MidTermLandEntity> {
 
     public static final QMidTermLandEntity midTermLandEntity = new QMidTermLandEntity("midTermLandEntity");
 
-    public final QBaseEntity _super = new QBaseEntity(this);
+    public final com.practice.weather.baseEntity.QBaseEntity _super = new com.practice.weather.baseEntity.QBaseEntity(this);
 
     //inherited
     public final DateTimePath<java.time.LocalDateTime> date = _super.date;

--- a/weather/src/main/generated/com/practice/weather/midTerm/ocean/entity/QMidTermOceanEntity.java
+++ b/weather/src/main/generated/com/practice/weather/midTerm/ocean/entity/QMidTermOceanEntity.java
@@ -2,7 +2,6 @@ package com.practice.weather.midTerm.ocean.entity;
 
 import static com.querydsl.core.types.PathMetadataFactory.*;
 
-import com.practice.weather.baseEntity.QBaseEntity;
 import com.querydsl.core.types.dsl.*;
 
 import com.querydsl.core.types.PathMetadata;
@@ -20,7 +19,7 @@ public class QMidTermOceanEntity extends EntityPathBase<MidTermOceanEntity> {
 
     public static final QMidTermOceanEntity midTermOceanEntity = new QMidTermOceanEntity("midTermOceanEntity");
 
-    public final QBaseEntity _super = new QBaseEntity(this);
+    public final com.practice.weather.baseEntity.QBaseEntity _super = new com.practice.weather.baseEntity.QBaseEntity(this);
 
     //inherited
     public final DateTimePath<java.time.LocalDateTime> date = _super.date;

--- a/weather/src/main/generated/com/practice/weather/midTerm/temperature/entity/QMidTermTemperatureEntity.java
+++ b/weather/src/main/generated/com/practice/weather/midTerm/temperature/entity/QMidTermTemperatureEntity.java
@@ -2,7 +2,6 @@ package com.practice.weather.midTerm.temperature.entity;
 
 import static com.querydsl.core.types.PathMetadataFactory.*;
 
-import com.practice.weather.baseEntity.QBaseEntity;
 import com.querydsl.core.types.dsl.*;
 
 import com.querydsl.core.types.PathMetadata;
@@ -20,7 +19,7 @@ public class QMidTermTemperatureEntity extends EntityPathBase<MidTermTemperature
 
     public static final QMidTermTemperatureEntity midTermTemperatureEntity = new QMidTermTemperatureEntity("midTermTemperatureEntity");
 
-    public final QBaseEntity _super = new QBaseEntity(this);
+    public final com.practice.weather.baseEntity.QBaseEntity _super = new com.practice.weather.baseEntity.QBaseEntity(this);
 
     //inherited
     public final DateTimePath<java.time.LocalDateTime> date = _super.date;

--- a/weather/src/main/generated/com/practice/weather/shortTerm/expectation/entity/QShortTermExpectationEntity.java
+++ b/weather/src/main/generated/com/practice/weather/shortTerm/expectation/entity/QShortTermExpectationEntity.java
@@ -2,7 +2,6 @@ package com.practice.weather.shortTerm.expectation.entity;
 
 import static com.querydsl.core.types.PathMetadataFactory.*;
 
-import com.practice.weather.baseEntity.QBaseEntity;
 import com.querydsl.core.types.dsl.*;
 
 import com.querydsl.core.types.PathMetadata;
@@ -20,7 +19,7 @@ public class QShortTermExpectationEntity extends EntityPathBase<ShortTermExpecta
 
     public static final QShortTermExpectationEntity shortTermExpectationEntity = new QShortTermExpectationEntity("shortTermExpectationEntity");
 
-    public final QBaseEntity _super = new QBaseEntity(this);
+    public final com.practice.weather.baseEntity.QBaseEntity _super = new com.practice.weather.baseEntity.QBaseEntity(this);
 
     public final StringPath baseDate = createString("baseDate");
 

--- a/weather/src/main/generated/com/practice/weather/shortTerm/extra/entity/QShortTermExtraEntity.java
+++ b/weather/src/main/generated/com/practice/weather/shortTerm/extra/entity/QShortTermExtraEntity.java
@@ -2,7 +2,6 @@ package com.practice.weather.shortTerm.extra.entity;
 
 import static com.querydsl.core.types.PathMetadataFactory.*;
 
-import com.practice.weather.baseEntity.QBaseEntity;
 import com.querydsl.core.types.dsl.*;
 
 import com.querydsl.core.types.PathMetadata;
@@ -20,7 +19,7 @@ public class QShortTermExtraEntity extends EntityPathBase<ShortTermExtraEntity> 
 
     public static final QShortTermExtraEntity shortTermExtraEntity = new QShortTermExtraEntity("shortTermExtraEntity");
 
-    public final QBaseEntity _super = new QBaseEntity(this);
+    public final com.practice.weather.baseEntity.QBaseEntity _super = new com.practice.weather.baseEntity.QBaseEntity(this);
 
     public final StringPath baseDate = createString("baseDate");
 

--- a/weather/src/main/generated/com/practice/weather/shortTerm/status/entity/QShortTermStatusEntity.java
+++ b/weather/src/main/generated/com/practice/weather/shortTerm/status/entity/QShortTermStatusEntity.java
@@ -2,7 +2,6 @@ package com.practice.weather.shortTerm.status.entity;
 
 import static com.querydsl.core.types.PathMetadataFactory.*;
 
-import com.practice.weather.baseEntity.QBaseEntity;
 import com.querydsl.core.types.dsl.*;
 
 import com.querydsl.core.types.PathMetadata;
@@ -20,7 +19,7 @@ public class QShortTermStatusEntity extends EntityPathBase<ShortTermStatusEntity
 
     public static final QShortTermStatusEntity shortTermStatusEntity = new QShortTermStatusEntity("shortTermStatusEntity");
 
-    public final QBaseEntity _super = new QBaseEntity(this);
+    public final com.practice.weather.baseEntity.QBaseEntity _super = new com.practice.weather.baseEntity.QBaseEntity(this);
 
     public final StringPath baseDate = createString("baseDate");
 

--- a/weather/src/main/java/com/practice/weather/midTerm/expectation/controller/MidTermExpectationController.java
+++ b/weather/src/main/java/com/practice/weather/midTerm/expectation/controller/MidTermExpectationController.java
@@ -44,8 +44,9 @@ public class MidTermExpectationController {
 
     
     // 중기 전망 예보 조회 실시간
+    @Deprecated
     @GetMapping("/mid-term/expectation/current/{location}")
-    public String midTermExpectationCurrent (
+    private String midTermExpectationCurrent (
             @PathVariable String location
     ) throws JsonProcessingException {
 

--- a/weather/src/main/java/com/practice/weather/midTerm/land/controller/MidTermLandController.java
+++ b/weather/src/main/java/com/practice/weather/midTerm/land/controller/MidTermLandController.java
@@ -44,8 +44,9 @@ public class MidTermLandController {
 
 
     // 중기 육상 예보 조회 실시간
+    @Deprecated
     @GetMapping("/mid-term/land/current/{location}")
-    public String midTermLandController(
+    private String midTermLandController(
             @PathVariable String location
     ) throws JsonProcessingException {
 

--- a/weather/src/main/java/com/practice/weather/midTerm/land/entity/MidTermLandEntity.java
+++ b/weather/src/main/java/com/practice/weather/midTerm/land/entity/MidTermLandEntity.java
@@ -13,6 +13,11 @@ import javax.persistence.*;
 @NoArgsConstructor
 @Table(name = "mid_term_land")
 @Entity(name = "MidTermLandEntity")
+@SequenceGenerator(
+        name = "MID_TERM_LAND_ID_GENERATOR",
+        sequenceName = "MID_TERM_LAND_ID",
+        initialValue = 1,
+        allocationSize = 1)
 public class MidTermLandEntity extends BaseEntity {
 
     @Id

--- a/weather/src/main/java/com/practice/weather/midTerm/ocean/controller/MidTermOceanController.java
+++ b/weather/src/main/java/com/practice/weather/midTerm/ocean/controller/MidTermOceanController.java
@@ -44,8 +44,9 @@ public class MidTermOceanController {
 
 
     // 중기 해상 예보 조회 실시간
+    @Deprecated
     @GetMapping("/mid-term/ocean/current/{location}")
-    public String midTermOceanController(
+    private String midTermOceanController(
             @PathVariable String location
     ) throws JsonProcessingException {
 

--- a/weather/src/main/java/com/practice/weather/midTerm/temperature/controller/MidTermTemperatureController.java
+++ b/weather/src/main/java/com/practice/weather/midTerm/temperature/controller/MidTermTemperatureController.java
@@ -44,8 +44,9 @@ public class MidTermTemperatureController {
 
 
     // 중기 기온 조회 실시간
+    @Deprecated
     @GetMapping("/mid-term/temperature/current/{location}")
-    public String midTermTemperatureController(
+    private String midTermTemperatureController(
             @PathVariable String location
     ) throws JsonProcessingException {
 

--- a/weather/src/main/java/com/practice/weather/shortTerm/expectation/controller/ShortTermExpectationController.java
+++ b/weather/src/main/java/com/practice/weather/shortTerm/expectation/controller/ShortTermExpectationController.java
@@ -47,8 +47,9 @@ public class ShortTermExpectationController {
 
 
     // 단기 예보 조회 실시간
+    @Deprecated
     @GetMapping("/short-term/expectation/current/{nxValue}/{nyValue}")
-    public String shortTermExpectationController(
+    private String shortTermExpectationController(
             @PathVariable String nxValue,
             @PathVariable String nyValue
     ) throws JsonProcessingException {

--- a/weather/src/main/java/com/practice/weather/shortTerm/expectation/service/ShortTermExpectationService.java
+++ b/weather/src/main/java/com/practice/weather/shortTerm/expectation/service/ShortTermExpectationService.java
@@ -8,6 +8,7 @@ import java.util.List;
 public interface ShortTermExpectationService {
 
     // Map 형태의 데이터를 DTO 객체 List 로 변환
+    @Deprecated
     List<ShortTermExpectationDto> parseJsonArrayToShortTermExpectationDto(JSONArray jArray, String version);
     
 }

--- a/weather/src/main/java/com/practice/weather/shortTerm/expectation/service/impl/ShortTermExpectationServiceImpl.java
+++ b/weather/src/main/java/com/practice/weather/shortTerm/expectation/service/impl/ShortTermExpectationServiceImpl.java
@@ -12,6 +12,7 @@ import java.util.List;
 @Service
 public class ShortTermExpectationServiceImpl implements ShortTermExpectationService {
 
+    @Deprecated
     @Override
     public List<ShortTermExpectationDto> parseJsonArrayToShortTermExpectationDto(JSONArray jArray, String version) {
 

--- a/weather/src/main/java/com/practice/weather/shortTerm/extra/controller/ShortTermExtraController.java
+++ b/weather/src/main/java/com/practice/weather/shortTerm/extra/controller/ShortTermExtraController.java
@@ -47,8 +47,9 @@ public class ShortTermExtraController {
 
 
     // 초단기 예보 조회 실시간
+    @Deprecated
     @GetMapping("/short-term/extra/current/{nxValue}/{nyValue}")
-    public String shortTermExtraController(
+    private String shortTermExtraController(
             @PathVariable String nxValue,
             @PathVariable String nyValue
     ) throws JsonProcessingException {

--- a/weather/src/main/java/com/practice/weather/shortTerm/extra/service/ShortTermExtraService.java
+++ b/weather/src/main/java/com/practice/weather/shortTerm/extra/service/ShortTermExtraService.java
@@ -8,5 +8,6 @@ import java.util.List;
 public interface ShortTermExtraService {
 
     // Map 형태의 데이터를 DTO 객체 List 로 변환
+    @Deprecated
     List<ShortTermExtraDto> parseJsonArrayToShortTermExtraDto(JSONArray jArray, String version);
 }

--- a/weather/src/main/java/com/practice/weather/shortTerm/extra/service/impl/ShortTermExtraServiceImpl.java
+++ b/weather/src/main/java/com/practice/weather/shortTerm/extra/service/impl/ShortTermExtraServiceImpl.java
@@ -12,6 +12,7 @@ import java.util.List;
 @Service
 public class ShortTermExtraServiceImpl implements ShortTermExtraService {
 
+    @Deprecated
     @Override
     public List<ShortTermExtraDto> parseJsonArrayToShortTermExtraDto(JSONArray jArray, String version) {
 

--- a/weather/src/main/java/com/practice/weather/shortTerm/status/controller/ShortTermStatusController.java
+++ b/weather/src/main/java/com/practice/weather/shortTerm/status/controller/ShortTermStatusController.java
@@ -44,8 +44,9 @@ public class ShortTermStatusController {
 
 
     // 초단기 실황 조회 실시간
+    @Deprecated
     @GetMapping("/short-term/status/current/{nxValue}/{nyValue}")
-    public String shortTermStatusController(
+    private String shortTermStatusController(
             @PathVariable String nxValue,
             @PathVariable String nyValue
     ) throws JsonProcessingException {

--- a/weather/src/main/java/com/practice/weather/shortTerm/status/service/ShortTermStatusService.java
+++ b/weather/src/main/java/com/practice/weather/shortTerm/status/service/ShortTermStatusService.java
@@ -6,5 +6,6 @@ import org.json.JSONArray;
 public interface ShortTermStatusService {
 
     // Map 형태의 데이터를 DTO 객체로 변환
+    @Deprecated
     ShortTermStatusDto parseJsonArrayToShortTermStatusDto(JSONArray jArray, String version);
 }

--- a/weather/src/main/java/com/practice/weather/shortTerm/status/service/impl/ShortTermStatusServiceImpl.java
+++ b/weather/src/main/java/com/practice/weather/shortTerm/status/service/impl/ShortTermStatusServiceImpl.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Service;
 @Service
 public class ShortTermStatusServiceImpl implements ShortTermStatusService {
 
+    @Deprecated
     @Override
     public ShortTermStatusDto parseJsonArrayToShortTermStatusDto(JSONArray jArray, String version) {
 

--- a/weather/src/main/java/com/practice/weather/utility/Utility.java
+++ b/weather/src/main/java/com/practice/weather/utility/Utility.java
@@ -27,6 +27,7 @@ public class Utility {
     private String serviceKey;
 
     // URL 연결 메소드
+    @Deprecated
     public JSONArray getDataAsJsonArray(String urlStr) {
 
         try {
@@ -39,7 +40,7 @@ public class Utility {
             // 타입 설정
             connection.setRequestProperty("CONTENT-TYPE", "application/json");
 
-            //openStream() : URL페이지 정보를 읽어온다.
+            //openStream() : URL 페이지 정보를 읽어온다.
             BufferedReader in = new BufferedReader(new InputStreamReader(url.openStream(), "utf-8"));
 
             String inputLine;
@@ -69,6 +70,7 @@ public class Utility {
     }
 
     // JSONArray > Map 파싱
+    @Deprecated
     public HashMap<String, String> parseJsonArrayToMap (JSONArray jArray) {
 
         HashMap<String, String> map = new HashMap<>();
@@ -119,6 +121,7 @@ public class Utility {
     }
 
     // 단기예보 BaseDate, BaseTime String[] Type 으로 return
+    @Deprecated
     public String[] getShortTermBaseDateTime(String serviceId) {
 
         SimpleDateFormat sdfDate = new SimpleDateFormat("yyyyMMdd");
@@ -158,6 +161,7 @@ public class Utility {
     }
 
     // 단기예보 버전 조회
+    @Deprecated
     public String getShortTermVersion (String serviceId, String dateTime) {
 
         String urlStr = "https://apis.data.go.kr/1360000/VilageFcstInfoService_2.0/getFcstVersion?" +


### PR DESCRIPTION
### regarding issue
- #16 

### key changes
- midTermEntity had sequence generator deleted by mistake at the last commit and it has been re-added
- mid/short-term current methods, alter map to dto methods, getVersion, get baseDate/Time methods are all no-longer used and deprecated controller methods are set private

### note
-
